### PR TITLE
feat(esx_addonaccount/server/main): Added GlobalState support

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -21,6 +21,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				end
 			end
 		end
+		GlobalState.AddonAccount.SharedAccounts = SharedAccounts
 
 		if next(newAccounts) then
 			MySQL.prepare('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
@@ -28,6 +29,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				local newAccount = newAccounts[i]
 				SharedAccounts[newAccount[1]] = CreateAddonAccount(newAccount[1], nil, 0)
 			end
+			GlobalState.AddonAccount.SharedAccounts = SharedAccounts
 		end
 	end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -21,7 +21,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				end
 			end
 		end
-		GlobalState['AddonAccount']:set('SharedAccounts', SharedAccounts, true)
+		GlobalState.SharedAccounts = SharedAccounts
 
 		if next(newAccounts) then
 			MySQL.prepare('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
@@ -29,7 +29,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				local newAccount = newAccounts[i]
 				SharedAccounts[newAccount[1]] = CreateAddonAccount(newAccount[1], nil, 0)
 			end
-			GlobalState['AddonAccount']:set('SharedAccounts', SharedAccounts, true)
+			GlobalState.SharedAccounts = SharedAccounts
 		end
 	end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -21,7 +21,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				end
 			end
 		end
-		GlobalState.AddonAccount.SharedAccounts = SharedAccounts
+		GlobalState['AddonAccount']:set('SharedAccounts', SharedAccounts, true)
 
 		if next(newAccounts) then
 			MySQL.prepare('INSERT INTO addon_account_data (account_name, money) VALUES (?, ?)', newAccounts)
@@ -29,7 +29,7 @@ AddEventHandler('onResourceStart', function(resourceName)
 				local newAccount = newAccounts[i]
 				SharedAccounts[newAccount[1]] = CreateAddonAccount(newAccount[1], nil, 0)
 			end
-			GlobalState.AddonAccount.SharedAccounts = SharedAccounts
+			GlobalState['AddonAccount']:set('SharedAccounts', SharedAccounts, true)
 		end
 	end
 end)


### PR DESCRIPTION
Added globalstate support for shared account table for faster and more optimized access to the table from other scripts instead of the callback function on the event